### PR TITLE
Changes to shashlik-install

### DIFF
--- a/scripts/shashlik-install
+++ b/scripts/shashlik-install
@@ -16,7 +16,6 @@ args = parser.parse_args()
 apk_path = args.apk
 
 def message(msg):
-    print (msg)
     try:
         subprocess.call(args=["kdialog",
                              "--title", "Shashlik",

--- a/scripts/shashlik-install
+++ b/scripts/shashlik-install
@@ -17,9 +17,12 @@ apk_path = args.apk
 
 def message(msg):
     print (msg)
-    subprocess.call(args=["kdialog",
-                         "--title", "Shashlik",
-                         "--msgbox", msg])
+    try:
+        subprocess.call(args=["kdialog",
+                             "--title", "Shashlik",
+                             "--msgbox", msg])
+    except:
+         pass
     sys.exit(msg)
 
 try:


### PR DESCRIPTION
-Workaround for devices that does not have kdialog, example Ubuntu with unity 7
-Remove of printing message twice, sys.exit() already takes care of printing
