### PR TITLE
Update shashlik-run: File handling

### DIFF
--- a/scripts/shashlik-run
+++ b/scripts/shashlik-run
@@ -44,18 +44,22 @@ class ShashlikController(http.server.BaseHTTPRequestHandler):
         apk_name = args.package_name
         apk_path = shashlik_dir + "/" + apk_name + ".apk"
         if os.path.exists(apk_path):
-            s.send_response(200)
-            s.send_header("Content-type", "application/vnd.android.package-archive")
-            s.end_headers()
-            with open(apk_path, "rb") as apk_file:
+            apk_file = open(apk_path, "rb")
+            if apk_file:
+                s.send_response(200)
+                s.send_header("Content-type", "application/vnd.android.package-archive")
+                s.end_headers()
                 while True:
                     chunk = apk_file.read(1024)
                     if (not chunk):
                         break
                     s.wfile.write(chunk)
-            os.unlink(apk_path)
+                apk_file.close()
+            else:
+                s.send_response(403)
+                s.end_headers()
         else:
-            s.send_response(403)
+            s.send_response(404)
             s.end_headers()
 
     def startup(s):
@@ -148,8 +152,6 @@ def install_app(package_path):
                                       universal_newlines=True)
         print (out)
         rc = "Success" in out
-        if rc:
-            os.unlink(apk_path)
         return rc
     except:
         return False


### PR DESCRIPTION
Update shashlik-run's file handling:

Properly handles any file error, giving a 403 error if it is unable to open a file and a 404 error if the apk file does not exist.
Removed the os.unlink statement that deleted the APK files after serving them via HTTP.
Removed the os.unlink statement that deleted the APK after installing it using ADB.
